### PR TITLE
feat(api): implement Deribit DataLab API client

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultTimeout    = 30 * time.Second
+	maxRetries        = 3
+	retryInterval     = 2 * time.Second
+	userAgent         = "greeks_news_bot"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}
+}
+
+func (c *Client) doRequest(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			slog.Info("retrying request", "endpoint", endpoint, "attempt", attempt+1)
+			time.Sleep(retryInterval)
+		}
+
+		err := c.doSingleRequest(ctx, endpoint, body, result)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		slog.Warn("request failed", "endpoint", endpoint, "attempt", attempt+1, "error", err)
+	}
+
+	return fmt.Errorf("all retries failed: %w", lastErr)
+}
+
+func (c *Client) doSingleRequest(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if err := json.Unmarshal(respBody, result); err != nil {
+		return fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) GetIVHistory(ctx context.Context) (*IVHistoryResponse, error) {
+	body := map[string]string{
+		"currency": "BTC",
+		"gap":      "7D",
+		"exchange": "deribit",
+	}
+
+	var resp APIResponse[IVHistoryResponse]
+	if err := c.doRequest(ctx, "/api/v1/deribit/datalab/iv_history", body, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 200 {
+		return nil, fmt.Errorf("api error: code=%d, message=%s", resp.Code, resp.Message)
+	}
+
+	return &resp.Data, nil
+}
+
+func (c *Client) GetIVRV(ctx context.Context) (*IVRVResponse, error) {
+	body := map[string]string{
+		"currency": "BTC",
+		"gap":      "1M",
+		"exchange": "deribit",
+	}
+
+	var resp APIResponse[IVRVResponse]
+	if err := c.doRequest(ctx, "/api/v1/deribit/datalab/iv_rv", body, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 200 {
+		return nil, fmt.Errorf("api error: code=%d, message=%s", resp.Code, resp.Message)
+	}
+
+	return &resp.Data, nil
+}
+
+func (c *Client) GetSkewChart(ctx context.Context) (*SkewChartResponse, error) {
+	body := map[string]string{
+		"currency": "BTC",
+		"gap":      "1M",
+		"exchange": "deribit",
+	}
+
+	var resp APIResponse[SkewChartResponse]
+	if err := c.doRequest(ctx, "/api/v1/deribit/datalab/skew_chart", body, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 200 {
+		return nil, fmt.Errorf("api error: code=%d, message=%s", resp.Code, resp.Message)
+	}
+
+	return &resp.Data, nil
+}
+
+func (c *Client) GetFIVMatrix(ctx context.Context) (*FIVMatrixResponse, error) {
+	body := map[string]interface{}{
+		"currency": "BTC",
+		"page_num": 0,
+		"exchange": "deribit",
+	}
+
+	var resp APIResponse[FIVMatrixResponse]
+	if err := c.doRequest(ctx, "/api/v1/deribit/datalab/fiv_matrix", body, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 200 {
+		return nil, fmt.Errorf("api error: code=%d, message=%s", resp.Code, resp.Message)
+	}
+
+	return &resp.Data, nil
+}
+
+func (c *Client) GetOptionFlows(ctx context.Context) (*OptionFlowsResponse, error) {
+	body := map[string]string{
+		"currency": "BTC",
+		"exchange": "deribit",
+	}
+
+	var resp APIResponse[OptionFlowsResponse]
+	if err := c.doRequest(ctx, "/api/v1/deribit/datalab/option_flows", body, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 200 {
+		return nil, fmt.Errorf("api error: code=%d, message=%s", resp.Code, resp.Message)
+	}
+
+	return &resp.Data, nil
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestClient_GetIVHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/deribit/datalab/iv_history" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("User-Agent") != "greeks_news_bot" {
+			t.Errorf("unexpected user agent: %s", r.Header.Get("User-Agent"))
+		}
+
+		resp := APIResponse[IVHistoryResponse]{
+			Code:    200,
+			Message: "",
+			Data: IVHistoryResponse{
+				Items: []IVHistoryData{
+					{Tenor: "1D", IV: 45.5, HV: 42.0, Date: "2026-02-08"},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.GetIVHistory(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result.Items))
+	}
+	if result.Items[0].IV != 45.5 {
+		t.Errorf("expected IV 45.5, got %f", result.Items[0].IV)
+	}
+}
+
+func TestClient_GetIVRV(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[IVRVResponse]{
+			Code: 200,
+			Data: IVRVResponse{
+				Items: []IVRVData{
+					{Period: "7D", IV: 50.0, RV: 45.0, VRP: 5.0},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.GetIVRV(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Items[0].VRP != 5.0 {
+		t.Errorf("expected VRP 5.0, got %f", result.Items[0].VRP)
+	}
+}
+
+func TestClient_GetSkewChart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[SkewChartResponse]{
+			Code: 200,
+			Data: SkewChartResponse{
+				Items: []SkewData{
+					{Tenor: "1M", Skew: 1.05, Date: "2026-02-08"},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.GetSkewChart(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Items[0].Skew != 1.05 {
+		t.Errorf("expected skew 1.05, got %f", result.Items[0].Skew)
+	}
+}
+
+func TestClient_GetFIVMatrix(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[FIVMatrixResponse]{
+			Code: 200,
+			Data: FIVMatrixResponse{
+				Items: []FIVMatrixEntry{
+					{FromTenor: "1W", ToTenor: "1M", FIV: 48.5},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.GetFIVMatrix(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Items[0].FIV != 48.5 {
+		t.Errorf("expected FIV 48.5, got %f", result.Items[0].FIV)
+	}
+}
+
+func TestClient_GetOptionFlows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[OptionFlowsResponse]{
+			Code: 200,
+			Data: OptionFlowsResponse{
+				Data: OptionFlowsData{
+					CallBuys:  1000.0,
+					CallSells: 800.0,
+					PutBuys:   600.0,
+					PutSells:  500.0,
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.GetOptionFlows(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Data.CallBuys != 1000.0 {
+		t.Errorf("expected CallBuys 1000.0, got %f", result.Data.CallBuys)
+	}
+}
+
+func TestClient_RetryOnFailure(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := APIResponse[IVHistoryResponse]{
+			Code: 200,
+			Data: IVHistoryResponse{Items: []IVHistoryData{}},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.GetIVHistory(context.Background())
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestClient_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[IVHistoryResponse]{
+			Code:    500,
+			Message: "internal error",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.GetIVHistory(context.Background())
+	if err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,73 @@
+package api
+
+// APIResponse is the common response wrapper
+type APIResponse[T any] struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    T      `json:"data"`
+}
+
+// IVHistoryData represents IV history for different tenors
+type IVHistoryData struct {
+	Tenor string  `json:"tenor"`
+	IV    float64 `json:"iv"`
+	HV    float64 `json:"hv"`
+	Date  string  `json:"date"`
+}
+
+// IVHistoryResponse contains the IV history data
+type IVHistoryResponse struct {
+	Items []IVHistoryData `json:"items"`
+}
+
+// IVRVData represents IV vs RV comparison
+type IVRVData struct {
+	Period string  `json:"period"`
+	IV     float64 `json:"iv"`
+	RV     float64 `json:"rv"`
+	VRP    float64 `json:"vrp"`
+}
+
+// IVRVResponse contains IV/RV data
+type IVRVResponse struct {
+	Items []IVRVData `json:"items"`
+}
+
+// SkewData represents skew for a tenor
+type SkewData struct {
+	Tenor string  `json:"tenor"`
+	Skew  float64 `json:"skew"`
+	Date  string  `json:"date"`
+}
+
+// SkewChartResponse contains skew chart data
+type SkewChartResponse struct {
+	Items []SkewData `json:"items"`
+}
+
+// FIVMatrixEntry represents a forward IV entry
+type FIVMatrixEntry struct {
+	FromTenor string  `json:"from_tenor"`
+	ToTenor   string  `json:"to_tenor"`
+	FIV       float64 `json:"fiv"`
+}
+
+// FIVMatrixResponse contains forward IV matrix
+type FIVMatrixResponse struct {
+	Items []FIVMatrixEntry `json:"items"`
+}
+
+// OptionFlowsData represents option flow data
+type OptionFlowsData struct {
+	CallBuys   float64 `json:"call_buys"`
+	CallSells  float64 `json:"call_sells"`
+	PutBuys    float64 `json:"put_buys"`
+	PutSells   float64 `json:"put_sells"`
+	BlockBuys  float64 `json:"block_buys"`
+	BlockSells float64 `json:"block_sells"`
+}
+
+// OptionFlowsResponse contains option flows
+type OptionFlowsResponse struct {
+	Data OptionFlowsData `json:"data"`
+}

--- a/openspec/changes/api-client/proposal.md
+++ b/openspec/changes/api-client/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: api-client
+
+## Motivation
+
+实现 Deribit DataLab API 客户端，用于获取 BTC 期权波动率市场数据。
+
+## Scope
+
+- 创建 HTTP 客户端，支持 POST 请求
+- 实现 5 个 API 接口调用
+- 实现重试机制（3 次，间隔 2 秒）
+- 定义响应数据结构
+
+## Non-goals
+
+- 不实现数据持久化（由 data-storage 负责）
+- 不实现报告生成逻辑
+- 不实现其他交易所支持
+
+## Risks
+
+- API 响应格式变化可能导致解析失败
+- 网络超时需要合理处理

--- a/openspec/changes/api-client/specs/api.md
+++ b/openspec/changes/api-client/specs/api.md
@@ -1,0 +1,78 @@
+# Spec: Deribit DataLab API Client
+
+## Overview
+
+Deribit DataLab API 客户端，用于获取 BTC 期权波动率数据。
+
+## API Endpoints
+
+Base URL: `https://dev-api.yazhan.vip`
+Header: `User-Agent: greeks_news_bot`
+
+### 1. IV History
+
+```
+POST /api/v1/deribit/datalab/iv_history
+Body: {"currency": "BTC", "gap": "7D", "exchange": "deribit"}
+```
+
+Response: 各期限（1D/1W/1M/2M/3M/6M/1Y）的 IV 数据及 HV 对照
+
+### 2. IV/RV
+
+```
+POST /api/v1/deribit/datalab/iv_rv
+Body: {"currency": "BTC", "gap": "1M", "exchange": "deribit"}
+```
+
+Response: 各周期的 IV、RV、VRP
+
+### 3. Skew Chart
+
+```
+POST /api/v1/deribit/datalab/skew_chart
+Body: {"currency": "BTC", "gap": "1M", "exchange": "deribit"}
+```
+
+Response: 各期限偏斜值
+
+### 4. FIV Matrix
+
+```
+POST /api/v1/deribit/datalab/fiv_matrix
+Body: {"currency": "BTC", "page_num": 0, "exchange": "deribit"}
+```
+
+Response: 远期 IV 期限结构矩阵
+
+### 5. Option Flows
+
+```
+POST /api/v1/deribit/datalab/option_flows
+Body: {"currency": "BTC", "exchange": "deribit"}
+```
+
+Response: 24h 内 call/put 买卖量
+
+## Client Interface
+
+```go
+type Client struct {
+    baseURL    string
+    httpClient *http.Client
+    userAgent  string
+}
+
+func NewClient(baseURL string) *Client
+func (c *Client) GetIVHistory(ctx context.Context) (*IVHistoryResponse, error)
+func (c *Client) GetIVRV(ctx context.Context) (*IVRVResponse, error)
+func (c *Client) GetSkewChart(ctx context.Context) (*SkewChartResponse, error)
+func (c *Client) GetFIVMatrix(ctx context.Context) (*FIVMatrixResponse, error)
+func (c *Client) GetOptionFlows(ctx context.Context) (*OptionFlowsResponse, error)
+```
+
+## Retry Policy
+
+- Max retries: 3
+- Retry interval: 2 seconds
+- Timeout: 30 seconds per request

--- a/openspec/changes/api-client/tasks.md
+++ b/openspec/changes/api-client/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: api-client
+
+## Implementation Tasks
+
+- [x] 定义 API 响应数据结构 (types.go)
+- [x] 实现 HTTP 客户端基础结构 (client.go)
+- [x] 实现 IV History 接口
+- [x] 实现 IV/RV 接口
+- [x] 实现 Skew Chart 接口
+- [x] 实现 FIV Matrix 接口
+- [x] 实现 Option Flows 接口
+- [x] 实现重试机制
+- [x] 添加单元测试


### PR DESCRIPTION
## Summary

- HTTP client with retry mechanism (3 retries, 2s interval)
- 5 API endpoints: IV History, IV/RV, Skew Chart, FIV Matrix, Option Flows
- Response type definitions with generics
- Unit tests with mock server (7 tests, all passing)

## Spec Change

OpenSpec/changes/api-client

## Related Issue

Closes #2

## Test Plan

- [x] All 7 unit tests pass
- [x] Mock server validates User-Agent header
- [x] Retry mechanism tested with failing requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)